### PR TITLE
Fix loop initialization for finding minimum value

### DIFF
--- a/Problems_on_Arrays/SmallInArray.java
+++ b/Problems_on_Arrays/SmallInArray.java
@@ -11,7 +11,7 @@ public class SmallInArray {
             arr[i]=sc.nextInt();
         }
         int min=arr[0];
-        for (int i=0;i<n;i++){
+        for (int i=1;i<n;i++){
             if (arr[i]<min){
                 min=arr[i];
             }


### PR DESCRIPTION
This PR updates the loop initialization from i = 0 to i = 1.

Since the minimum value is already initialized with arr[0], starting the loop
from index 1 avoids an unnecessary comparison with itself in the first iteration.

This improves code clarity and slightly optimizes the logic.